### PR TITLE
fixes #426

### DIFF
--- a/lp/ui/marc.py
+++ b/lp/ui/marc.py
@@ -46,7 +46,9 @@ mapping = (
     ('BIOGRAPHICAL NOTES', 'Biographical Notes', ['545']),
     ('CURRENT_FREQUENCY', 'Current Frequency', ['310', '321', '362']),
     ('PUBLICATION_HISTORY', 'Publication History', ['362']),
-    ('IN_COLLECTION', 'In Collection', ['773']),
+    ('IN_COLLECTION', 'In Collection', [
+        ('773', None, None, 'abdghikmnopqrstuwxyz')
+    ]),
     ('THESIS_DISSERTATION', 'Thesis/Dissertation', ['502']),
     ('CONTENTS', 'Contents', ['505']),
     ('PRODUCTION_CREDITS', 'Production Credits', ['508']),

--- a/lp/ui/tests/marc_test.py
+++ b/lp/ui/tests/marc_test.py
@@ -216,7 +216,7 @@ class MarcExtractTests(unittest.TestCase):
     def test_in_collection_773(self):
         r = self.get_record("773.mrc")
         bib_data = extract(r)
-        self.assertEqual(bib_data["IN_COLLECTION"], ['c2as American Historical Association. Annual report of the American Historical Association. Washington. 25 cm. v. 2 [1897] (OCoLC)1150082'])
+        self.assertEqual(bib_data["IN_COLLECTION"], ['American Historical Association. Annual report of the American Historical Association. Washington. 25 cm. v. 2 [1897] (OCoLC)1150082'])
 
     def test_notes_500(self):
         r = self.get_record("500.mrc")


### PR DESCRIPTION
@cummingsm it might worth looking at the subfields I chose to extract from the 773 compared to the [full list](http://loc.gov/marc/bibliographic/bd773.html). I decided to go with all the alphabetical ones, and ignored the 3, 4, 6, 7 and 8 subfields.
