### PR TITLE
Update launchpad.css

### DIFF
--- a/lp/ui/static/css/launchpad.css
+++ b/lp/ui/static/css/launchpad.css
@@ -162,10 +162,6 @@ td.field-label {
     padding: 1.2em 1em .5em 0;
 }
 
-#description {
-    float: left;
-}
-
 #cover-image {
     border-left: 1px solid #ddd;
     border-bottom: 1px solid #ddd;


### PR DESCRIPTION
Removed float on text so that title/bibliographic info remains to right of the cover image instead of bumping below.
Fixes #251
