### PR TITLE
fix inter-library-loan link display

### DIFF
--- a/lp/ui/views.py
+++ b/lp/ui/views.py
@@ -173,6 +173,7 @@ def non_wrlc_item(request, num, num_type):
                   'non_gw': True,
                   'holdings': holdings,
                   'link': '',
+                  'show_ill_link': True
                   })
 
 


### PR DESCRIPTION
This should fix #534. The logic around when to display an ILL link should probably be simplified and have a test added for it at some point when time allows.
