### PR TITLE
changed page title to GW Libraries from GWU Libraries

### DIFF
--- a/lp/ui/templates/base.html
+++ b/lp/ui/templates/base.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>{% block title %}{% endblock title %} - GWU Libraries</title>
+<title>{% block title %}{% endblock title %} - GW Libraries</title>
 <link rel="icon" href="{{ STATIC_URL}}img/favicon.ico" type="image/x-icon" />
 <!-- 'viewport' helps mobile devices scale appropriately -->
 <meta name="viewport" content="width=device-width, initial-scale=1.0" /> 


### PR DESCRIPTION
Changed base.html to update page title from GWU Libraries to GW Libraries (branding)
Fixes #647 
