### PR TITLE
results beyond - holdings only search

### DIFF
--- a/lp/ui/views.py
+++ b/lp/ui/views.py
@@ -432,7 +432,7 @@ def search(request):
             'Institution,or',
             'Discipline,or',
         ],
-        "ho": "f",
+        "ho": "t",
         "light": "t",
         "raw": raw,
     }


### PR DESCRIPTION
setting [Holdings Only](http://api.summon.serialssolutions.com/help/api/search/parameters/holdings-only) to true when doing the Summon search seems to fix the problem of non-launchpad items showing up in the search results. I'm not sure why I was explicitly setting it to false before. This brings Launchpad in line with Obento's book search, which also [sets it to true](https://github.com/gwu-libraries/obento/blob/master/obi/obi/local_settings.py.template#L77).
