### PR TITLE
Move caching directives to urls.py as opposed to views.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ the path according to your installation of oracle.
 6. Install django, cx_Oracle, and other python dependencies
 
         pip install -r requirements.txt
+        easy_install pytz
 
 7. *Note*: Voyager's Oracle implementation *requires* ASCII encoding on
    database connections.  Django strictly mandates UTF8 encodings on 
@@ -152,7 +153,9 @@ Edit wsgi file:
 - Change parameter for site.addsitedir() to your local path. You
   will need to change the path and possibly the Python version number.
 
-If you want to use memcached, configure and ensure it has started:
+If you want to use memcached, uncomment the example CACHES and
+ITEM_PAGE_CACHE_SECONDS settings. Configure memcached and ensure it has
+started:
 
         sudo vim /etc/memcached.conf
         sudo /etc/init.d/memcached start

--- a/lp/lp/local_settings.py.template
+++ b/lp/lp/local_settings.py.template
@@ -164,15 +164,17 @@ GOVT_DOC_LINK = 'purl.access.gpo.gov'
 
 BOUND_WITH_ITEM_LINK = 'findit.library.gwu.edu/item/'
 
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
-        'LOCATION': '127.0.0.1:11211',
-        'TIMEOUT': 60 * 60,  # default to one hour
-        }
-    }
+# Uncomment CACHES and ITEM_PAGE_CACHE_SECONDS to override default (dummy) caching
 
-ITEM_PAGE_CACHE_SECONDS = 60 * 60 # one hour
+#CACHES = {
+#    'default': {
+#        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+#        'LOCATION': '127.0.0.1:11211',
+#        'TIMEOUT': 60 * 60,  # default to one hour
+#        }
+#    }
+#
+#ITEM_PAGE_CACHE_SECONDS = 60 * 60 # one hour
 
 # If this value is present (not empty), GA bug will be added to html
 GOOGLE_ANALYTICS_UA = ''

--- a/lp/lp/settings.py
+++ b/lp/lp/settings.py
@@ -9,6 +9,15 @@ ADMINS = (
 
 MANAGERS = ADMINS
 
+#Default cache settings, for testing purposes
+CACHES = {
+    'default' : {
+        'BACKEND' : 'django.core.cache.backends.dummy.DummyCache',
+    }
+}
+
+ITEM_PAGE_CACHE_SECONDS = 0; #view decorators require this value to be populated
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.oracle', # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.

--- a/lp/lp/urls.py
+++ b/lp/lp/urls.py
@@ -1,44 +1,51 @@
 from django.conf import settings
 from django.conf.urls import patterns, url
 from django.views.generic import TemplateView
+from ui import views
+from django.views.decorators.cache import cache_page
 
 
 handler500 = 'ui.views.error500'
+cache_time = settings.ITEM_PAGE_CACHE_SECONDS
 
 urlpatterns = patterns('ui.views',
-    url(r'^$', 'home', name='home'),
-    url(r'^item/(?P<bibid>\d{2,8})$', 'item', name='item'),
-    url(r'^item/(?P<bibid>\d{2,8}).json$', 'item_json', name='item_json'),
-    url(r'^item/(?P<bibid>\d{2,8})/marc.json$', 'item_marc', name='item_marc'),
-    url(r'^item/\.?(?P<gtbibid>b\d{2,8}x?)$', 'gtitem', name='gtitem'),
-    url(r'^item/\.?(?P<gtbibid>b\d{2,8}x?).json$', 'gtitem_json',
-        name='gtitem_json'),
-    url(r'^item/m(?P<gmbibid>\d{2,8})$', 'gmitem', name='gmitem'),
-    url(r'^item/m(?P<gmbibid>\d{2,8}).json$', 'gmitem_json',
-        name='gmitem_json'),
-    url(r'^issn/(?P<issn>\d{4}-?\d{3}[0-9Xx])$', 'issn', name='issn'),
-    url(r'^isbn/(?P<isbn>[0-9-xX]+)$', 'isbn', name='isbn'),
-    url(r'^isbn/(?P<isbn>[0-9-xX]+) .*$', 'isbn'),
-    url(r'^oclc/\(OCoLC\)oc[mn](?P<oclc>\d{6,10})$', 'oclc'),
-    url(r'^oclc/\(OCoLC\)(?P<oclc>\d{6,10})$', 'oclc'),
-    url(r'^oclc/\(OCoLC\)on(?P<oclc>\d{6,10})$', 'oclc'),
-    url(r'^oclc/oc[mn](?P<oclc>\d{6,10})$', 'oclc'),
-    url(r'^oclc/on(?P<oclc>\d{6,10})$', 'oclc'),
-    url(r'^oclc/\(Safari\)(?P<oclc>\d{6,10})$', 'oclc'),
-    url(r'^oclc/(?P<oclc>\d{6,10})$', 'oclc', name='oclc'),
+    url(r'^$', views.home, name='home'),
+    url(r'^item/(?P<bibid>\d{2,8})$', cache_page(cache_time)(views.item),
+        name='item'),
+    url(r'^item/(?P<bibid>\d{2,8}).json$', 
+        cache_page(cache_time)(views.item_json), name='item_json'),
+    url(r'^item/(?P<bibid>\d{2,8})/marc.json$', 
+        cache_page(cache_time)(views.item_marc), name='item_marc'),
+    url(r'^item/\.?(?P<gtbibid>b\d{2,8}x?)$', 
+        cache_page(cache_time)(views.gtitem), name='gtitem'),
+    url(r'^item/\.?(?P<gtbibid>b\d{2,8}x?).json$', 
+        cache_page(cache_time)(views.gtitem_json), name='gtitem_json'),
+    url(r'^item/m(?P<gmbibid>\d{2,8})$', 
+        cache_page(cache_time)(views.gmitem), name='gmitem'),
+    url(r'^item/m(?P<gmbibid>\d{2,8}).json$', 
+        cache_page(cache_time)(views.gmitem_json), name='gmitem_json'),
+    url(r'^issn/(?P<issn>\d{4}-?\d{3}[0-9Xx])$', views.issn, name='issn'),
+    url(r'^isbn/(?P<isbn>[0-9-xX]+)$', views.isbn, name='isbn'),
+    url(r'^isbn/(?P<isbn>[0-9-xX]+) .*$', views.isbn),
+    url(r'^oclc/\(OCoLC\)oc[mn](?P<oclc>\d{6,10})$', views.oclc),
+    url(r'^oclc/\(OCoLC\)(?P<oclc>\d{6,10})$', views.oclc),
+    url(r'^oclc/\(OCoLC\)on(?P<oclc>\d{6,10})$', views.oclc),
+    url(r'^oclc/oc[mn](?P<oclc>\d{6,10})$', views.oclc),
+    url(r'^oclc/on(?P<oclc>\d{6,10})$', views.oclc),
+    url(r'^oclc/\(Safari\)(?P<oclc>\d{6,10})$', views.oclc),
+    url(r'^oclc/(?P<oclc>\d{6,10})$', views.oclc, name='oclc'),
     url(r'^about/', TemplateView.as_view(template_name='about.html'),
         name='about'),
     url(r'^api/', TemplateView.as_view(template_name='api.html'),
         name='api'),
-    url(r'^robots.txt$', 'robots', name='robots'),
-    url(r'^503.html$', 'error503', name='error503'),
-    url(r'^search$', 'search', name='search'),
-    url(r'^advanced$', 'advanced_search', name='advanced_search'),
-    url(r'^availability$', 'availability', name='availability'),
-    url(r'^related$', 'related', name='related')
+    url(r'^robots.txt$', views.robots, name='robots'),
+    url(r'^503.html$', views.error503, name='error503'),
+    url(r'^search$', views.search, name='search'),
+    url(r'^availability$', views.availability, name='availability'),
+    url(r'^related$', views.related, name='related')
 )
 
 if settings.ENABLE_HUMANS:
     urlpatterns += patterns('ui.views',
-        url(r'^humans.txt$', 'humans', name='humans'),
+        url(r'^humans.txt$', views.humans, name='humans'),
     )

--- a/lp/ui/views.py
+++ b/lp/ui/views.py
@@ -24,10 +24,6 @@ def home(request):
         'title': 'launchpad home',
     })
 
-def advanced_search(request):
-    return render(request, 'advanced_search.html', {
-        'title': 'Advanced Search',
-    })
 
 def _openurl_dict(request):
     params = request.GET
@@ -47,7 +43,6 @@ def citation_json(request):
     return bibjsontools.from_openurl(url) if url else None
 
 
-@cache_page(settings.ITEM_PAGE_CACHE_SECONDS)
 def item(request, bibid):
     bib = None
     try:
@@ -121,7 +116,6 @@ def _date_handler(obj):
     return obj.isoformat() if hasattr(obj, 'isoformat') else obj
 
 
-@cache_page(settings.ITEM_PAGE_CACHE_SECONDS)
 def item_json(request, bibid, z3950='False', school=None):
     try:
         bib_data = voyager.get_bib_data(bibid)
@@ -140,7 +134,6 @@ def item_json(request, bibid, z3950='False', school=None):
         return error500(request)
 
 
-@cache_page(settings.ITEM_PAGE_CACHE_SECONDS)
 def item_marc(request, bibid):
     rec = voyager.get_marc_blob(bibid)
     if not rec:
@@ -149,7 +142,6 @@ def item_marc(request, bibid):
     return HttpResponse(rec.as_json(indent=2), content_type='application/json')
 
 
-@cache_page(settings.ITEM_PAGE_CACHE_SECONDS)
 def non_wrlc_item(request, num, num_type):
     bib = apis.get_bib_data(num=num, num_type=num_type)
     if not bib:
@@ -223,7 +215,6 @@ def gtitem(request, gtbibid):
         return error500(request)
 
 
-@cache_page(settings.ITEM_PAGE_CACHE_SECONDS)
 def gtitem_json(request, gtbibid):
     try:
         bibid = db.get_bibid_from_gtid(gtbibid)
@@ -275,7 +266,6 @@ def unicode_data(bib_data):
     return bib_encoded
 
 
-@cache_page(settings.ITEM_PAGE_CACHE_SECONDS)
 def gmitem(request, gmbibid):
     try:
         bibid = db.get_bibid_from_gmid(gmbibid)
@@ -317,7 +307,6 @@ def gmitem(request, gmbibid):
         return error500(request)
 
 
-@cache_page(settings.ITEM_PAGE_CACHE_SECONDS)
 def gmitem_json(request, gmbibid):
     try:
         bibid = voyager.get_bibid_from_gmid(gmbibid)
@@ -521,7 +510,6 @@ def search(request):
 
         search_results = _remove_genre_ebook_facet(search_results)
         search_results = _reorder_facets(search_results)
-        search_results = _remove_active_facets(request, search_results)
         search_results = _format_facets(request, search_results)
 
         return render(request, 'search.html', {
@@ -576,17 +564,6 @@ def _remove_genre_ebook_facet(search_results):
                 if count['name'] != 'electronic books':
                     new_counts.append(count)
             facet['counts'] = new_counts
-    return search_results
-
-
-def _remove_active_facets(request, search_results):
-    facets = request.GET.getlist('facet', [])
-    for facet in search_results['facets']:
-        new_counts = []
-        for count in facet['counts']:
-            if "%s:%s" % (facet['name'], count['name']) not in facets:
-                new_counts.append(count)
-        facet['counts'] = new_counts
     return search_results
 
 


### PR DESCRIPTION
Removed the cache_page decorators from the views file and instead put the caching directives in the urls file, so as to leave the actual views untouched.

Updated the settings.py to include a default cache mechanism (dummy cache) as well as a default cache time, which is required for caching the views.

Updated readme to reflect configuration changes.
