### PR TITLE
ignore items with no holdings

### DIFF
--- a/lp/ui/summon.py
+++ b/lp/ui/summon.py
@@ -65,6 +65,9 @@ class Summon():
         for doc in summon_response['documents']:
             item = self._convert(doc)
             if item:
+                # only include items that are held by a library
+                if len(item['offers']) == 0:
+                    continue
                 # sometimes (rarely) the same item appears more than once?
                 # e.g. search for "statistics"
                 if item['@id'] in seen:


### PR DESCRIPTION
This change means that summon results that lack holdings are filtered out of launchpad results.
