### PR TITLE
include wrlc shared ebooks in peer documents.

### DIFF
--- a/lp/ui/summon.py
+++ b/lp/ui/summon.py
@@ -143,19 +143,13 @@ class Summon():
             i['alternateName'] = doc.get('DocumentTitle_FL')[0]
 
         i['offers'] = []
-        if doc.get('Institution'):
-            i['offers'].append(self._get_offer(doc))
-        if doc.get('peerDocuments'):
-            for peer_doc in doc.get('peerDocuments'):
-                offer = self._get_offer(peer_doc)
-                if offer:
-                    i['offers'].append(offer)
-        if doc.get('LCCallNum') == ['Shared Electronic Book']:
-            i['offers'].append({
-                'seller': 'WRLC',
-                'serialNumber': doc['ExternalDocumentID'][0]
-            })
-
+        offer = self._get_offer(doc)
+        if offer:
+            i['offers'].append(offer)
+        for peer_doc in doc.get('peerDocuments', []):
+            offer = self._get_offer(peer_doc)
+            if offer:
+                i['offers'].append(offer)
         i = self._rewrite_ids(i)
 
         return i
@@ -170,6 +164,12 @@ class Summon():
                 'seller': inst,
                 'serialNumber': id
             }
+        elif doc.get('LCCallNum') == ['Shared Electronic Book']:
+            offer = {
+                'seller': 'WRLC',
+                'serialNumber': doc['ExternalDocumentID'][0]
+            }
+
         return offer
 
     def _rewrite_ids(self, item):


### PR DESCRIPTION
Search results should now always include WRLC shared ebooks. fixes #802 
