### PR TITLE
Move cache designation from views to urls

### DIFF
--- a/lp/lp/urls.py
+++ b/lp/lp/urls.py
@@ -1,48 +1,49 @@
 from django.conf import settings
 from django.conf.urls import patterns, url
 from django.views.generic import TemplateView
+from ui import views
 
 
 handler500 = 'ui.views.error500'
 
 urlpatterns = patterns(
     'ui.views',
-    url(r'^$', 'home', name='home'),
-    url(r'^catalog/$', 'home', name='catalog'),
-    url(r'^item/(?P<bibid>\d{2,8})$', 'item', name='item'),
-    url(r'^item/(?P<bibid>\d{2,8}).json$', 'item_json', name='item_json'),
-    url(r'^item/(?P<bibid>\d{2,8})/marc.json$', 'item_marc', name='item_marc'),
-    url(r'^item/\.?(?P<gtbibid>b\d{2,8}x?)$', 'gtitem', name='gtitem'),
-    url(r'^item/\.?(?P<gtbibid>b\d{2,8}x?).json$', 'gtitem_json',
+    url(r'^$', views.home, name='home'),
+    url(r'^catalog/$', views.home, name='catalog'),
+    url(r'^item/(?P<bibid>\d{2,8})$', views.item, name='item'),
+    url(r'^item/(?P<bibid>\d{2,8}).json$', views.item_json, name='item_json'),
+    url(r'^item/(?P<bibid>\d{2,8})/marc.json$', views.item_marc, name='item_marc'),
+    url(r'^item/\.?(?P<gtbibid>b\d{2,8}x?)$', views.gtitem, name='gtitem'),
+    url(r'^item/\.?(?P<gtbibid>b\d{2,8}x?).json$', views.gtitem_json,
         name='gtitem_json'),
-    url(r'^item/m(?P<gmbibid>\d{2,8})$', 'gmitem', name='gmitem'),
-    url(r'^item/m(?P<gmbibid>\d{2,8}).json$', 'gmitem_json',
+    url(r'^item/m(?P<gmbibid>\d{2,8})$', views.gmitem, name='gmitem'),
+    url(r'^item/m(?P<gmbibid>\d{2,8}).json$', views.gmitem_json,
         name='gmitem_json'),
-    url(r'^issn/(?P<issn>\d{4}-?\d{3}[0-9Xx])$', 'issn', name='issn'),
-    url(r'^isbn/(?P<isbn>[0-9-xX]+)$', 'isbn', name='isbn'),
-    url(r'^isbn/(?P<isbn>[0-9-xX]+) .*$', 'isbn'),
-    url(r'^oclc/\(OCoLC\)oc[mn](?P<oclc>\d{6,10})$', 'oclc'),
-    url(r'^oclc/\(OCoLC\)(?P<oclc>\d{6,10})$', 'oclc'),
-    url(r'^oclc/\(OCoLC\)on(?P<oclc>\d{6,10})$', 'oclc'),
-    url(r'^oclc/oc[mn](?P<oclc>\d{6,10})$', 'oclc'),
-    url(r'^oclc/on(?P<oclc>\d{6,10})$', 'oclc'),
-    url(r'^oclc/\(Safari\)(?P<oclc>\d{6,10})$', 'oclc'),
-    url(r'^oclc/(?P<oclc>\d{6,10})$', 'oclc', name='oclc'),
+    url(r'^issn/(?P<issn>\d{4}-?\d{3}[0-9Xx])$', views.issn, name='issn'),
+    url(r'^isbn/(?P<isbn>[0-9-xX]+)$', views.isbn, name='isbn'),
+    url(r'^isbn/(?P<isbn>[0-9-xX]+) .*$', views.isbn),
+    url(r'^oclc/\(OCoLC\)oc[mn](?P<oclc>\d{6,10})$', views.oclc),
+    url(r'^oclc/\(OCoLC\)(?P<oclc>\d{6,10})$', views.oclc),
+    url(r'^oclc/\(OCoLC\)on(?P<oclc>\d{6,10})$', views.oclc),
+    url(r'^oclc/oc[mn](?P<oclc>\d{6,10})$', views.oclc),
+    url(r'^oclc/on(?P<oclc>\d{6,10})$', views.oclc),
+    url(r'^oclc/\(Safari\)(?P<oclc>\d{6,10})$', views.oclc),
+    url(r'^oclc/(?P<oclc>\d{6,10})$', views.oclc, name='oclc'),
     url(r'^about/', TemplateView.as_view(template_name='about.html'),
         name='about'),
     url(r'^api/', TemplateView.as_view(template_name='api.html'),
         name='api'),
-    url(r'^robots.txt$', 'robots', name='robots'),
-    url(r'^503.html$', 'error503', name='error503'),
-    url(r'^search$', 'search', name='search'),
-    url(r'^advanced/$', 'advanced_search', name='advanced_search'),
-    url(r'^availability$', 'availability', name='availability'),
-    url(r'^related$', 'related', name='related'),
-    url(r'^tips/$', 'tips', name='tips')
+    url(r'^robots.txt$', views.robots, name='robots'),
+    url(r'^503.html$', views.error503, name='error503'),
+    url(r'^search$', views.search, name='search'),
+    url(r'^advanced/$', views.advanced_search, name='advanced_search'),
+    url(r'^availability$', views.availability, name='availability'),
+    url(r'^related$', views.related, name='related'),
+    url(r'^tips/$', views.tips, name='tips')
 )
 
 if settings.ENABLE_HUMANS:
     urlpatterns += patterns(
         'ui.views',
-        url(r'^humans.txt$', 'humans', name='humans'),
+        url(r'^humans.txt$', views.humans, name='humans'),
     )

--- a/lp/lp/urls.py
+++ b/lp/lp/urls.py
@@ -2,22 +2,29 @@ from django.conf import settings
 from django.conf.urls import patterns, url
 from django.views.generic import TemplateView
 from ui import views
-
+from django.views.decorators.cache import cache_page
 
 handler500 = 'ui.views.error500'
+
+cache_seconds = getattr(settings, 'ITEM_PAGE_CACHE_SECONDS', 0)
+cache_wrap = cache_page(cache_seconds) #returns a function to wrap a view w/ cache
 
 urlpatterns = patterns(
     'ui.views',
     url(r'^$', views.home, name='home'),
     url(r'^catalog/$', views.home, name='catalog'),
-    url(r'^item/(?P<bibid>\d{2,8})$', views.item, name='item'),
-    url(r'^item/(?P<bibid>\d{2,8}).json$', views.item_json, name='item_json'),
-    url(r'^item/(?P<bibid>\d{2,8})/marc.json$', views.item_marc, name='item_marc'),
-    url(r'^item/\.?(?P<gtbibid>b\d{2,8}x?)$', views.gtitem, name='gtitem'),
-    url(r'^item/\.?(?P<gtbibid>b\d{2,8}x?).json$', views.gtitem_json,
+    url(r'^item/(?P<bibid>\d{2,8})$', cache_wrap(views.item), name='item'),
+    url(r'^item/(?P<bibid>\d{2,8}).json$', cache_wrap(views.item_json), 
+        name='item_json'),
+    url(r'^item/(?P<bibid>\d{2,8})/marc.json$', cache_wrap(views.item_marc), 
+        name='item_marc'),
+    url(r'^item/\.?(?P<gtbibid>b\d{2,8}x?)$', cache_wrap(views.gtitem), 
+        name='gtitem'),
+    url(r'^item/\.?(?P<gtbibid>b\d{2,8}x?).json$', cache_wrap(views.gtitem_json),
         name='gtitem_json'),
-    url(r'^item/m(?P<gmbibid>\d{2,8})$', views.gmitem, name='gmitem'),
-    url(r'^item/m(?P<gmbibid>\d{2,8}).json$', views.gmitem_json,
+    url(r'^item/m(?P<gmbibid>\d{2,8})$', cache_wrap(views.gmitem), 
+        name='gmitem'),
+    url(r'^item/m(?P<gmbibid>\d{2,8}).json$', cache_wrap(views.gmitem_json),
         name='gmitem_json'),
     url(r'^issn/(?P<issn>\d{4}-?\d{3}[0-9Xx])$', views.issn, name='issn'),
     url(r'^isbn/(?P<isbn>[0-9-xX]+)$', views.isbn, name='isbn'),

--- a/lp/ui/views.py
+++ b/lp/ui/views.py
@@ -50,7 +50,6 @@ def citation_json(request):
     return bibjsontools.from_openurl(url) if url else None
 
 
-@cache_page(settings.ITEM_PAGE_CACHE_SECONDS)
 def item(request, bibid):
     bib = None
     try:
@@ -124,7 +123,6 @@ def _date_handler(obj):
     return obj.isoformat() if hasattr(obj, 'isoformat') else obj
 
 
-@cache_page(settings.ITEM_PAGE_CACHE_SECONDS)
 def item_json(request, bibid, z3950='False', school=None):
     try:
         bib_data = voyager.get_bib_data(bibid)
@@ -143,7 +141,6 @@ def item_json(request, bibid, z3950='False', school=None):
         return error500(request)
 
 
-@cache_page(settings.ITEM_PAGE_CACHE_SECONDS)
 def item_marc(request, bibid):
     rec = voyager.get_marc_blob(bibid)
     if not rec:
@@ -152,7 +149,6 @@ def item_marc(request, bibid):
     return HttpResponse(rec.as_json(indent=2), content_type='application/json')
 
 
-@cache_page(settings.ITEM_PAGE_CACHE_SECONDS)
 def non_wrlc_item(request, num, num_type):
     bib = apis.get_bib_data(num=num, num_type=num_type)
     if not bib:
@@ -188,7 +184,6 @@ def non_wrlc_item(request, num, num_type):
                   })
 
 
-@cache_page(settings.ITEM_PAGE_CACHE_SECONDS)
 def gtitem(request, gtbibid):
     try:
         bibid = db.get_bibid_from_gtid(gtbibid)
@@ -230,7 +225,6 @@ def gtitem(request, gtbibid):
         return error500(request)
 
 
-@cache_page(settings.ITEM_PAGE_CACHE_SECONDS)
 def gtitem_json(request, gtbibid):
     try:
         bibid = db.get_bibid_from_gtid(gtbibid)
@@ -282,7 +276,6 @@ def unicode_data(bib_data):
     return bib_encoded
 
 
-@cache_page(settings.ITEM_PAGE_CACHE_SECONDS)
 def gmitem(request, gmbibid):
     try:
         bibid = db.get_bibid_from_gmid(gmbibid)
@@ -324,7 +317,6 @@ def gmitem(request, gmbibid):
         return error500(request)
 
 
-@cache_page(settings.ITEM_PAGE_CACHE_SECONDS)
 def gmitem_json(request, gmbibid):
     try:
         bibid = voyager.get_bibid_from_gmid(gmbibid)


### PR DESCRIPTION
This keeps the default views from being modified by the caching decorators, in the event that we should want to access the unmodified view. It also shifts the urls.py to using the actual objects from views.py, as opposed to their textual names.

This addresses issue #748

Note that the travis-ci test will fail, because pull requests cannot access the encrypted environment variables: http://docs.travis-ci.com/user/pull-requests/#Security-Restrictions-when-testing-Pull-Requests