### PR TITLE
limit 700 personal author to subfield a,d. fixes #882

### DIFF
--- a/lp/ui/marc.py
+++ b/lp/ui/marc.py
@@ -33,7 +33,7 @@ def gacs(field):
 mapping = (
     ('STANDARD_TITLE', 'Standard Title', ['240']),
     ('OTHER_TITLE', 'Other Title', ['130', '242', '246', '730', '740', '247']),
-    ('OTHER_AUTHORS', 'Other Authors', ['700', '710', '711']),
+    ('OTHER_AUTHORS', 'Other Authors', [('700', None, None, 'a,d'), '710', '711']),
     ('EARLIER_TITLE', 'Earlier Title', ['247', '780']),
     ('TITLE_CHANGED_TO', 'Title Changed To', ['785']),
     ('SUBJECTS', 'Subjects', ['650', '600', '610', '630', '651']),


### PR DESCRIPTION
Fix applies to Details tab, which marc.py controls. Cannot omit subfield e on bib level because name and descriptor is all part of the bib_index.display_heading field from Voyager.
