### PR TITLE
made key lookup more defensive, fixes #1033

### DIFF
--- a/lp/ui/db.py
+++ b/lp/ui/db.py
@@ -524,7 +524,8 @@ def _get_offers_z3950(id, library):
                          id, library, h)
 
         # some locations have a weird period before the name
-        o['availabilityAtOrFrom'] = o['availabilityAtOrFrom'].lstrip('.')
+        o['availabilityAtOrFrom'] = o.get('availabilityAtOrFrom',
+                                          '').lstrip('.')
 
         offers.append(o)
 


### PR DESCRIPTION
I am unable to reproduce the error on the backend, but it looks like there's a problem with the holdings data underlying this issue that you might need to investigate.  In the meantime this pull request should at least eliminate the KeyErrors we've been getting, but I'm doubting it solves the underlying problem.