### PR TITLE
added Meta Tag to disable IE compat mode

### DIFF
--- a/lp/ui/templates/base.html
+++ b/lp/ui/templates/base.html
@@ -2,6 +2,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta http-equiv="X-UA-Compatible" content="IE=Edge" >
 <title>{% block title %}{% endblock title %} - GW Libraries</title>
 <link rel="icon" href="{{ STATIC_URL}}img/favicon.ico" type="image/x-icon" />
 <!-- 'viewport' helps mobile devices scale appropriately -->


### PR DESCRIPTION
fixes #1049

IE doesn't load stylesheets in compatibility mode, so stop IE users from using compatibility mode.