### PR TITLE
removing alpha sort

### DIFF
--- a/lp/ui/summon.py
+++ b/lp/ui/summon.py
@@ -121,7 +121,7 @@ class Summon():
                     'name': subject,
                     'url': reverse('search') + '?' + urlencode({'q': q})
                 })
-                i['about'] = sorted(i['about'])
+                # i['about'] = sorted(i['about'])
 
         if doc.get('PublicationYear'):
             i['datePublished'] = doc['PublicationYear'][0]


### PR DESCRIPTION
Saw that this was not included in m33_001. Seems still relevant, acknowledging we may wish to further analysis of subject headings and refine order and number that display.  

Fixes #1044
