### PR TITLE
Indicate Spec and temp location if Spec is perm loc. Fixes #1105

### DIFF
--- a/lp/ui/templates/item.html
+++ b/lp/ui/templates/item.html
@@ -318,16 +318,23 @@
                                     <br /> {{ item.TEMPLOCATION }}
                                 {% endif %}
                             {% elif item.TEMPLOCATION %}
-                                {{ item.TEMPLOCATION|noscream }}
-                                <br/>
+				{% if item.TRIMMED_LOCATION_DISPLAY_NAME == 'GELMAN Special Collections' %}
+					Gelman Special Collections <br/> {{ item.TEMPLOCATION }}
+				{% else %}
+					{{ item.TEMPLOCATION|noscream }} <br/>
+				{% endif %}
                                 {% if holding.ITEMS|length > max_items and forloop.counter == max_items %}
-                                    <input id="{{holding.BIB_ID}}1" type="button" value="[+] Show " style="border:none;background:none;color:#0088cc;" onclick="toggle_visibility('{{holding.BIB_ID}}','{{holding.BIB_ID}}1');">
+                                    <input id="{{holding.BIB_ID}}1" type="button" value="[+] Show " 
+					style="border:none;background:none;color:#0088cc;" 
+					onclick="toggle_visibility('{{holding.BIB_ID}}','{{holding.BIB_ID}}1');">
                                 {% endif %}
                             {% else %}
                                 {{ item.TRIMMED_LOCATION_DISPLAY_NAME|noscream }}
                                 <br />
                                 {% if holding.ITEMS|length > max_items and forloop.counter == max_items %}
-                                    <input id="{{holding.BIB_ID}}1" type="button" value="[+] Show " style="border:none;background:none;color:#0088cc;" onclick="toggle_visibility('{{holding.BIB_ID}}','{{holding.BIB_ID}}1');"> 
+                                    <input id="{{holding.BIB_ID}}1" type="button" value="[+] Show " 
+					style="border:none;background:none;color:#0088cc;" 
+					onclick="toggle_visibility('{{holding.BIB_ID}}','{{holding.BIB_ID}}1');"> 
                                 {% endif %}
                             {% endif %}
                         </div>


### PR DESCRIPTION
When item has a temporary location, show that the home location is Gelman Special Collections (ie the item's permanent location) if that is the case.