### PR TITLE
Refs #1004. Logsitter script and deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ only been tested on ubuntu 14.04 LTS.
 
         sudo apt-get install -y libxml2-dev libxslt1-dev zlib1g-dev
         sudo apt-get install apache2 libapache2-mod-wsgi libaio-dev python-dev python-profiler memcached libmemcached-dev  libxslt-dev sqlite3
+        sudo apt-get install supervisor
 
 
 2. Install git 
@@ -219,3 +220,17 @@ Make sure SITEMAPS_DIR exists, then run the management command:
 
 If you are in production mode, be sure to set ```DEBUG = False``` and 
 the appropriate ```ALLOWED_HOSTS``` in ```lp/local_settings.py```.
+
+- Set up `logsitter`.
+
+Logsitter is a script intended to be a workaround
+for #1004.  Logsitter monitors the apache log and as soon as it sees the
+error message referenced in #1004, it automatically restarts apache.
+To ensure that it stays running, logsitter is deployed with and managed by
+[supervisor](http://supervisord.org/).
+
+To set up logsitter, copy the logsitter supervisor configuration file,
+then restart supervisor:
+
+        sudo cp /launchpad/launchpad/scripts/logsitter.py /etc/supervisor/conf.d/
+        sudo service supervisor restart

--- a/README.md
+++ b/README.md
@@ -234,3 +234,8 @@ then restart supervisor:
 
         sudo cp /launchpad/launchpad/scripts/logsitter.py /etc/supervisor/conf.d/
         sudo service supervisor restart
+
+NOTE: If the /launchpad/launchpad/scripts directory is not owned by root, you
+must change its ownership to root:
+
+        sudo chown -R root:root /launchpad/launchpad/scripts/

--- a/README.md
+++ b/README.md
@@ -229,8 +229,8 @@ error message referenced in #1004, it automatically restarts apache.
 To ensure that it stays running, logsitter is deployed with and managed by
 [supervisor](http://supervisord.org/).
 
-If the /launchpad/launchpad/scripts directory is not owned by root, you
-must change its ownership to root:
+If the `/launchpad/launchpad/scripts` directory is not owned by `root`,
+change its ownership to `root`:
 
         sudo chown -R root:root /launchpad/launchpad/scripts/
 

--- a/README.md
+++ b/README.md
@@ -229,13 +229,13 @@ error message referenced in #1004, it automatically restarts apache.
 To ensure that it stays running, logsitter is deployed with and managed by
 [supervisor](http://supervisord.org/).
 
+If the /launchpad/launchpad/scripts directory is not owned by root, you
+must change its ownership to root:
+
+        sudo chown -R root:root /launchpad/launchpad/scripts/
+
 To set up logsitter, copy the logsitter supervisor configuration file,
 then restart supervisor:
 
         sudo cp /launchpad/launchpad/scripts/logsitter.py /etc/supervisor/conf.d/
         sudo service supervisor restart
-
-NOTE: If the /launchpad/launchpad/scripts directory is not owned by root, you
-must change its ownership to root:
-
-        sudo chown -R root:root /launchpad/launchpad/scripts/

--- a/scripts/logsitter.conf
+++ b/scripts/logsitter.conf
@@ -1,0 +1,10 @@
+# Place in /etc/supervisor/conf.d 
+# Then restart supervisor with:  sudo service supervisor restart
+#
+[program:logsitter]
+command=/usr/bin/python /launchpad/launchpad/scripts/logsitter.py
+directory=/home/kerchner
+autostart=true
+autorestart=true
+stderr_logfile=/var/log/logsitter.err.log
+stdout_logfile=/var/log/logsitter.out.log

--- a/scripts/logsitter.conf
+++ b/scripts/logsitter.conf
@@ -3,7 +3,6 @@
 #
 [program:logsitter]
 command=/usr/bin/python /launchpad/launchpad/scripts/logsitter.py
-directory=/home/kerchner
 autostart=true
 autorestart=true
 stderr_logfile=/var/log/logsitter.err.log

--- a/scripts/logsitter.py
+++ b/scripts/logsitter.py
@@ -1,0 +1,27 @@
+# NOTE: Must be run with sudo (running via supervisor accomplishes this)
+
+import datetime
+import time
+import subprocess
+import select
+
+f = subprocess.Popen(['tail','-F', '-n 0', '/var/log/apache2/error.log'],
+                     stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+p = select.poll()
+p.register(f.stdout)
+
+while True:
+    if p.poll(1):
+        logline = f.stdout.readline()
+        if 'DatabaseError: ORA-65535: Message 65535 not found;  product=RDBMS; facility=ORA' in logline:
+            # Kill the log tailing process; this way, we can start tailing it afresh
+            # after the restart.  Avoids multiple restarts associated with a single incident.
+            f.kill()
+            # Restart apache
+            subprocess.call(['echo','Restarting apache at %s' % datetime.datetime.now()])
+            subprocess.call(['service','apache2','restart'])
+            # Start a new log tailing process
+            f = subprocess.Popen(['tail','-F', '-n 0', '/var/log/apache2/error.log'],
+                     stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            p.register(f.stdout)
+    time.sleep(0.5)


### PR DESCRIPTION
Created logsitter script and updated README with supervisor deployment instructions. Refs #1004 (as a workaround, not a fix).  Monitors apache log for Oracle error and restarts as needed.